### PR TITLE
Locked down Werkzeug dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# Freeze these depndencies
+Werkzeug==1.0.1
+
 # Runtime dependencies
 Flask==1.1.1
 Flask-API==1.1


### PR DESCRIPTION
Thee new version of Werkzeug breaks Flask 1.x so we ned to ensure that we use an older version